### PR TITLE
Add dict to types of fields in i_update

### DIFF
--- a/misskey/misskey.py
+++ b/misskey/misskey.py
@@ -447,7 +447,7 @@ class Misskey:
         ] = None,
         avatar_id: Optional[str] = None,
         banner_id: Optional[str] = None,
-        fields: Optional[List[dict]] = None,
+        fields: Union[List[dict], dict, None] = None,
         is_locked: Optional[bool] = None,
         is_explorable: Optional[bool] = None,
         hide_online_status: Optional[bool] = None,
@@ -488,7 +488,7 @@ class Misskey:
 
             banner_id (:obj:`str`, optional): Banner's drive id.
 
-            fields (:obj:`list` of :obj:`dict`, optional):
+            fields (:obj:`list` of :obj:`dict` or :obj:`dict`, optional):
             Profile supplementary information.
 
             is_locked (:obj:`bool`, optional): Whether to make
@@ -550,6 +550,10 @@ class Misskey:
         if isinstance(birthday, datetime.date) or \
            isinstance(birthday, datetime.datetime):
             birthday = birthday.strftime('%Y-%m-%d')
+
+        if issubclass(type(fields), dict):
+            fields = [{'name': key, 'value': val}
+                      for key, val in fields.items()]
 
         if type(muting_notification_types) is list:
             for index, val in enumerate(muting_notification_types):

--- a/tests/test_misskey.py
+++ b/tests/test_misskey.py
@@ -411,6 +411,7 @@ def test_i_update(
         name='Unit test user admin',
         birthday=datetime.date.today(),
         lang='ja-JP',
+        fields={'name1': 'value1', 'name2': 'value2'},
         muting_notification_types=[
             'app',
         ],


### PR DESCRIPTION
`i_update` の `fields` 引数を辞書で指定できるようにしました。

`i_update(fields=[{'name': '名前', 'value': '値'}])` のように書かなければいけなかったところを `i_update(fields={'名前': '値'})` と書くことができるようにしました。