### PR TITLE
create korean locale of index

### DIFF
--- a/docs/locale/ko/LC_MESSAGES/index.po
+++ b/docs/locale/ko/LC_MESSAGES/index.po
@@ -1,9 +1,10 @@
 # Misskey.py documentation i18n file
 # Copyright (C) 2019-2023 YuzuRyo61
+# Copyleft (C) 2024 HotoRas
 # This file is distributed under the same license as the Misskey.py package.
 # YuzuRyo61 <yuzuryo61@yuzulia.work>, 2023.
 
-# TODO: 試験中のため変更される場合があります
+# TODO: Testing period- contents might change
 
 msgid ""
 msgstr ""

--- a/docs/locale/ko/LC_MESSAGES/index.po
+++ b/docs/locale/ko/LC_MESSAGES/index.po
@@ -1,0 +1,67 @@
+# Misskey.py documentation i18n file
+# Copyright (C) 2019-2023 YuzuRyo61
+# This file is distributed under the same license as the Misskey.py package.
+# YuzuRyo61 <yuzuryo61@yuzulia.work>, 2023.
+
+# TODO: 試験中のため変更される場合があります
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Misskey.py \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-09-01 09:07+0900\n"
+"PO-Revision-Date: 2024-09-01 09:07+0900\n"
+"Last-Translator: HotoRas <hotoras03@gmail.com>\n"
+"Language: ko\n"
+"Language-Team: ko <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.1\n"
+
+#: ../../index.rst:2
+msgid "Misskey.py"
+msgstr "Misskey.py"
+
+#: ../../index.rst:5
+msgid "Introduction"
+msgstr "소개"
+
+#: ../../index.rst:6
+msgid "Welcome to the official documentation of Misskey.py."
+msgstr "Misskey.py의 공식 문서에 오신 것을 환영합니다."
+
+#: ../../index.rst:8
+msgid ""
+"`Misskey`_ is a distributed social networking software compliant with "
+"ActivityPub. This library defines classes and other functions that can "
+"access its API."
+msgstr ""
+"`Misskey`_는 ActivityPub을 사용하는 탈중앙화 소셜 네트워킹 소프트웨어입니다."
+"이 라이브러리는 이의 API를 활용하기 위한 클래스 및 함수들을 정의하고 있습니다."
+
+#: ../../index.rst:13
+msgid "Usage"
+msgstr "사용법"
+
+#: ../../index.rst:15
+msgid "WIP (Misskey.py v5 is now in development)"
+msgstr "WIP (Misskey.py v5가 현재 개발 중입니다)"
+
+#: ../../index.rst:18
+msgid "Indices and tables"
+msgstr "Indices and tables"
+
+#: ../../index.rst:20
+msgid ":ref:`genindex`"
+msgstr ":ref:`genindex`"
+
+#: ../../index.rst:21
+msgid ":ref:`modindex`"
+msgstr ":ref:`modindex`"
+
+#: ../../index.rst:22
+msgid ":ref:`search`"
+msgstr ":ref:`search`"
+


### PR DESCRIPTION
Seems like the project is unmaintained for months;
however when I checked some defines of API path, it's compatible to latest Misskey (2024.3.0 and up).

I personally think this library could be used as API wrapper for korean
(they mostly use python or nodejs but the nodejs wrapper is far more complicated since it's live in actual soft),
so I wish translating docs to korean is useful.

If something is wrong or subject to change, please call me and I'll have it localized.